### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Docker Automated build](https://img.shields.io/docker/automated/thar/cmake-compiler-alpine.svg)](https://hub.docker.com/r/thar/cmake-compiler-alpine/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/thar/cmake-compiler-alpine.svg)](https://hub.docker.com/r/thar/cmake-compiler-alpine/)
-[![Docker Stars](https://img.shields.io/docker/stars/thar/cmake-compiler-alpine.svg)](https://hub.docker.com/r/thar/cmake-compiler-alpine/)
+[![Docker Stars](https://img.shields.io/docker/stars/thar/cmake-compiler-alpine.svg)](https://hub.docker.com/r/thar/cmake-compiler-alpine/) [![](https://images.microbadger.com/badges/image/thar/cmake-compiler-alpine.svg)](https://microbadger.com/images/thar/cmake-compiler-alpine "Get your own image badge on microbadger.com")
 
 # cmake-compiler-alpine
 Docker image to compile c++ cmake based projects
@@ -10,3 +10,4 @@ Prepare your compile/test script within your project and run:
 ```
 docker run -v <project_folder>:/app thar/cmake-compiler-alpine ./<your_script.sh>
 ```
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [thar/cmake-compiler-alpine](https://hub.docker.com/r/thar/cmake-compiler-alpine/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/thar/cmake-compiler-alpine).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/thar/cmake-compiler-alpine.svg)](https://microbadger.com/images/thar/cmake-compiler-alpine)
